### PR TITLE
Refactored translation contract and updated tests

### DIFF
--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,1 @@
+node_modules

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,22 @@
+{
+  "custom-rules-filename": null,
+  "rules": {
+    "imports-on-top": true,
+    "variable-declarations": true,
+    "array-declarations": true,
+    "operator-whitespace": true,
+    "lbrace": true,
+    "mixedcase": true,
+    "camelcase": true,
+    "uppercase": true,
+    "no-with": true,
+    "no-empty-blocks": true,
+    "no-unused-vars": true,
+    "double-quotes": true,
+    "blank-lines": true,
+    "indentation": true,
+    "whitespace": true,
+    "deprecated-suicide": true,
+    "pragma-on-top": true
+  }
+}

--- a/contracts/TranslationContract.sol
+++ b/contracts/TranslationContract.sol
@@ -8,18 +8,22 @@ contract TranslationContract {
 
     uint createdAt;
     address owner;
-    uint count;
+    Translation[] public translations;
+    uint public numTranslations;
 
+    //mapping to provide LUT of all translationIDs from particular address;    
+    mapping (address => uint[]) public requestsByAddress; 
 
     enum Languages{English, Spanish, Chinese, French}
 
     //A structure to store everything to do with each translation request 
-    struct TransObj {
+    struct Translation{
+        
         address originAddress;      //requestor address
         string originStr;           //string to be translated
         uint originLanguage;   
         uint destLanguage;
-        uint price;                 //amount to be awarded to translator
+        uint bounty;                //amount to be awarded to translator
         uint time;                  //timestamp of initial request
         bool completed;             //flag that the requestor can change or triggered after translation
         address transAddress;       //address of the translator
@@ -28,104 +32,89 @@ contract TranslationContract {
         //future variables: duration, reclaimed flag if expired 
     }
 
-    //array to support multiple translation requests from single address
-    mapping(address => TransObj[]) transMap;
-
-    //Look up table for front end
-    address[] public addressLUT;
-
     function TranslationContract() {
         createdAt = now;
         owner = msg.sender;
-        count = 0;
+        numTranslations = 0;
     }
 
-    event TranslationRequested(address addr, string str, uint value);
-    event TranslationSuccess(address addr, string str, uint value);
+    event TranslationRequested(uint translationID, address addr, string str, uint value);
+    event TranslationSuccess(uint translationID, address addr, string str, uint value);
     event TranslationFailed(address addr, string str, uint value);
 
-    function requestTranslation(string str, uint lang1, uint lang2) payable {
+    function newTranslation(string str, uint lang1, uint lang2) payable returns (uint translationID) {
         
         //get the array of translation objects for the requestor's address
-        TransObj memory tmp;
 
         if (msg.value > 0){
-            tmp.originAddress = msg.sender;
-            tmp.originStr = str;
-            tmp.originLanguage = lang1;
-            tmp.destLanguage = lang2;
-            tmp.price = msg.value;  //use the amount in txn
-            tmp.time = now;
-            tmp.completed = false;
 
-            transMap[msg.sender].push(tmp);
-            TranslationRequested(msg.sender, str, msg.value);
+            translationID = translations.length;
+            // Translation storage t = translations[translationID];
+            Translation memory t; 
             
-            //update LUT if it's the first transaction for the address
-            if (transMap[msg.sender].length < 2) addressLUT.push(msg.sender);
+            t.originAddress = msg.sender;
+            t.originStr = str;
+            t.originLanguage = lang1;
+            t.destLanguage = lang2;
+            t.bounty = msg.value;  //use the amount in txn
+            t.time = now;
+            t.completed = false;
+
+            translations.push(t);
+
+            TranslationRequested(translationID, msg.sender, str, msg.value);
+            //Add the translation ID to the mapping of address:translationID 
+            requestsByAddress[msg.sender].push(translationID);
+            numTranslations++;
         }
     }
 
     //function called to complete translation object + send reward to translator
     //'key' argument is the address of the requestor
-    function performTranslation(string str, address key) {
+    function performTranslation(string translatedText, uint translationID) {
         
-        TransObj[] memory requestor = transMap[key];
+        Translation storage t = translations[translationID];
+        //update original Translation object with translation
+        t.translatedStr = translatedText;
+        t.transAddress = msg.sender;
 
-        //check for the same string, completed == false, and value > 0
-        for (uint i=0; i<requestor.length; i++){
-            if (StringUtils.equal(requestor[i].originStr, str) && requestor[i].completed == false && requestor[i].price > 0 ){
-                //update object with translation
-                requestor[i].translatedStr = str;
-                requestor[i].transAddress = msg.sender;
-
-                //send the reward
-                msg.sender.transfer(requestor[i].price);
-                requestor[i].completed = true;
-                 TranslationSuccess(msg.sender, str, requestor[i].price);
-            } else {
-                //send failure Event and cancel transaction
-                TranslationFailed(msg.sender, str, requestor[i].price);
-                revert();
-            }
-        }
+        //send the reward
+        //TODO: how to put into if/assert statement?
+        msg.sender.transfer(t.bounty);
+        TranslationSuccess(translationID, msg.sender, t.translatedStr, t.bounty);
+        t.completed = true;
+        // } else {
+        //     TranslationFailed(translationID, msg.sender, t.translatedStr, t.bounty);
+        //     revert();
+        // }
     }
 
-    function isRequestor (string str) returns (uint) {
-        
-        TransObj[] memory requestor = transMap[msg.sender];
-
-        //check for the same string, completed == false
-        for (uint i=0; i<requestor.length; i++){
-            if (StringUtils.equal(requestor[i].originStr, str) && requestor[i].completed == false ){
-                //if the person sending the txn is the original requestor, grant permission
-                if (msg.sender == requestor[i].originAddress) {
-                    return i;
-                }
-            }
-        }
-        
-        //not the requestor
-        revert();
+    modifier requestorOnly (uint translationID) {
+        require(msg.sender == translations[translationID].originAddress);
+        _;
     }
 
-    function cancelTranslation(string str) {
-        uint position = isRequestor(str);
-        transMap[msg.sender][position].completed = true;
-    }
-
-    function getStringToTranslate(address adr) returns (bytes32[10]){
-        //ideally this would be dynamic... but we'll figure a way to optimize
-        bytes32[10] memory outputArray;
+    function cancelTranslation(uint translationID, string str) requestorOnly (translationID) {
        
-        TransObj[] memory requestor = transMap[adr];
+        //check to see if the string passed in is the same
+        require(StringUtils.equal(str,translations[translationID].originStr));
+        translations[translationID].completed = true;
+    }
 
-        for(uint i=0; i<requestor.length; i++ ){
-            bytes32 tmp = stringToBytes32(requestor[i].originStr);
+    function getAllOpenRequests() constant returns (bytes32[10]){
+        bytes32[10] memory outputArray;
+        for (uint i=0; i<translations.length; i++){
+            bytes32 tmp = stringToBytes32(translations[i].originStr);
             outputArray[i] = tmp;
         }
 
         return outputArray;
+    }
+
+    function getTranslatedString(uint translationID) constant returns (string){
+        Translation t = translations[translationID];
+        if(t.completed != true) return "ERROR: No translation found";
+        return t.translatedStr;
     }
 
     //this should be in Utils
@@ -136,6 +125,6 @@ contract TranslationContract {
     }
 
     //Solidity 0.4.17 apparently gives the ability to return custom objects externally - would like to play with this when it ships
-    // function getOpenTranslations() returns (TransObj[]){
+    // function getOpenTranslations() returns (Translation[]){
     // }
 }

--- a/contracts/TranslationContract.sol
+++ b/contracts/TranslationContract.sol
@@ -103,9 +103,11 @@ contract TranslationContract {
 
     function getAllOpenRequests() constant returns (bytes32[10]){
         bytes32[10] memory outputArray;
-        for (uint i=0; i<translations.length; i++){
-            bytes32 tmp = stringToBytes32(translations[i].originStr);
-            outputArray[i] = tmp;
+        for (uint i=0; i<translations.length; i++) {
+            if (translations[i].completed == false) {
+                bytes32 tmp = stringToBytes32(translations[i].originStr);
+                outputArray[i] = tmp;
+            }
         }
 
         return outputArray;

--- a/contracts/TranslationContract.sol
+++ b/contracts/TranslationContract.sol
@@ -17,7 +17,7 @@ contract TranslationContract {
     enum Languages{English, Spanish, Chinese, French}
 
     //A structure to store everything to do with each translation request 
-    struct Translation{
+    struct Translation {
         
         address originAddress;      //requestor address
         string originStr;           //string to be translated
@@ -46,7 +46,7 @@ contract TranslationContract {
         
         //get the array of translation objects for the requestor's address
 
-        if (msg.value > 0){
+        if (msg.value > 0) {
 
             translationID = translations.length;
             // Translation storage t = translations[translationID];
@@ -101,7 +101,7 @@ contract TranslationContract {
         translations[translationID].completed = true;
     }
 
-    function getAllOpenRequests() constant returns (bytes32[10]){
+    function getAllOpenRequests() constant returns (bytes32[10]) {
         bytes32[10] memory outputArray;
         for (uint i=0; i<translations.length; i++) {
             if (translations[i].completed == false) {
@@ -113,9 +113,11 @@ contract TranslationContract {
         return outputArray;
     }
 
-    function getTranslatedString(uint translationID) constant returns (string){
+    function getTranslatedString(uint translationID) constant returns (string) {
         Translation t = translations[translationID];
-        if(t.completed != true) return "ERROR: No translation found";
+        if (t.completed != true) {
+            return "ERROR: No translation found";
+        }
         return t.translatedStr;
     }
 

--- a/contracts/TranslationUtils.sol
+++ b/contracts/TranslationUtils.sol
@@ -11,6 +11,7 @@ contract TranslationUtils{
         return string(b);
     }
 
+
     //     function stringToBytes32(string memory source) returns (bytes32 result) {
     //     assembly {
     //         result := mload(add(source, 32))

--- a/test/translation.js
+++ b/test/translation.js
@@ -9,19 +9,43 @@ contract("TranslationContract", accounts => {
   it("should return the string to be translated", async () => {
     const translationInstance = await TranslationContract.deployed();
 
-    await translationInstance.requestTranslation(
+    await translationInstance.newTranslation(
       "Test Translation",
       Languages.English,
       Languages.French,
-      { from: joshs_address, value: 10 }
+      {from: joshs_address, value: 10 }
     );
 
-    const result = await translationInstance.getStringToTranslate.call(
-      joshs_address
+    await translationInstance.newTranslation(
+      "Hi, how are you?",
+      Languages.English,
+      Languages.French,
+      {from: joshs_address, value: 10 }
     );
-    const str = toAscii(result[0]).replace(/\0/g, "");
+
+    const result = await translationInstance.getAllOpenRequests.call();
+    const str = toAscii(result[1]).replace(/\0/g, "");
 
     console.log("Translation String = ", str);
-    assert.equal(str, "Test Translation");
+    assert.equal(str, "Hi, how are you?");
   });
+
+  it("should return a failed transaction because the string has not been translated", async () => {
+    const translationInstance = await TranslationContract.deployed();
+    const result = await translationInstance.getTranslatedString.call(0);
+    
+    console.log (result);
+  });
+
+  it("should return the translated string", async () => {
+    const translationInstance = await TranslationContract.deployed();
+
+    await translationInstance.performTranslation("Bonjour, comment ça va?", 1);
+    const result = await translationInstance.getTranslatedString.call(1);
+
+    console.log(result);
+    assert.equal(result,"Bonjour, comment ça va?");
+  
+  })
 });
+


### PR DESCRIPTION
**For requesting a new translation:**

Original:  
```
function requestTranslation(string str, uint lang1, uint lang2) payable
```
Now: 
```
function newTranslation(string str, uint lang1, uint lang2) payable returns (uint translationID) 
```

**For performing a translation:**
Original: 
```
function performTranslation(string str, address) 
```
New: 
```
function performTranslation(string translatedText, **uint translationID**) //the translationID can be tracked from when you first retrieve the translation request
```

**New function to retrieve a translated string**
```
function getTranslatedString(uint translationID) constant returns (string)
```

**New function to retrieve all open requests (currently limited to 10)**
```
function getAllOpenRequests() constant returns (bytes32[10])
```
Example usage of this in web3:
```
const result = await translationInstance.getAllOpenRequests.call();
const str = toAscii(result[1]).replace(/\0/g, "");
```